### PR TITLE
Fix ABI encoding of address arguments for getter calldata

### DIFF
--- a/src/staking_sdk_py/generateCalldata.py
+++ b/src/staking_sdk_py/generateCalldata.py
@@ -1,15 +1,10 @@
 from blake3 import blake3
 from eth_keys import keys
+from py_ecc.bls import G2ProofOfPossession as bls
+from typing import Union
+
 import staking_sdk_py.constants as constants
 import staking_sdk_py.keyGenerator as keyGenerator
-from typing import Union
-import eth_abi
-
-
-from blake3 import blake3
-from eth_keys import keys
-from py_ecc.bls import G2ProofOfPossession as bls
-from py_ecc.optimized_bls12_381 import curve_order
 
 from eth_abi import encode
 
@@ -39,57 +34,72 @@ def add_validator(
     secp_sig = secp_priv_key.sign_msg_hash_non_recoverable(blake3(payload).digest()).to_bytes()
     bls_sig = bls.Sign(bls_privkey, payload)
 
-    return "0x" + constants.ADD_VALIDATOR_SELECTOR + eth_abi.encode(['bytes', 'bytes', 'bytes'], [payload, secp_sig, bls_sig]).hex()
+    return "0x" + constants.ADD_VALIDATOR_SELECTOR + encode(['bytes', 'bytes', 'bytes'], [payload, secp_sig, bls_sig]).hex()
 
 
 def strip_0x(s: str) -> str:
     return s[2:] if s.startswith("0x") else s
 
+
+def _address_to_bytes(address: str) -> bytes:
+    """Convert a hex address to a 20-byte representation for ABI encoding."""
+    if not isinstance(address, str):
+        raise TypeError("Address must be provided as a string")
+
+    sanitized = strip_0x(address)
+    if len(sanitized) != 40:
+        raise ValueError("Address must be 20 bytes (40 hex characters)")
+
+    try:
+        return bytes.fromhex(sanitized)
+    except ValueError as exc:
+        raise ValueError("Address contains non-hex characters") from exc
+
 def delegate(validator_id: Union[int, str]) -> str:
-    return "0x" + constants.DELEGATE_SELECTOR + eth_abi.encode(['uint64'], [validator_id]).hex()
+    return "0x" + constants.DELEGATE_SELECTOR + encode(['uint64'], [validator_id]).hex()
 
 def undelegate(validator_id: Union[int, str], amount: Union[int, str], withdraw_id: int) -> str:
-    return "0x" + constants.UNDELEGATE_SELECTOR + eth_abi.encode(['uint64', 'uint256', 'uint8'], [validator_id, amount, withdraw_id]).hex()
+    return "0x" + constants.UNDELEGATE_SELECTOR + encode(['uint64', 'uint256', 'uint8'], [validator_id, amount, withdraw_id]).hex()
 
 def withdraw(validator_id: Union[int, str], withdraw_id: int) -> str:
-    return "0x" + constants.WITHDRAW_SELECTOR + eth_abi.encode(['uint64', 'uint8'], [validator_id, withdraw_id]).hex()
+    return "0x" + constants.WITHDRAW_SELECTOR + encode(['uint64', 'uint8'], [validator_id, withdraw_id]).hex()
 
 def compound(validator_id: Union[int, str]) -> str:
-    return "0x" + constants.COMPOUND_SELECTOR + eth_abi.encode(['uint64'], [validator_id]).hex()
+    return "0x" + constants.COMPOUND_SELECTOR + encode(['uint64'], [validator_id]).hex()
 
 def claim_rewards(validator_id: Union[int, str]) -> str:
-    return "0x" + constants.CLAIM_REWARDS_SELECTOR + eth_abi.encode(['uint64'], [validator_id]).hex()
+    return "0x" + constants.CLAIM_REWARDS_SELECTOR + encode(['uint64'], [validator_id]).hex()
 
 def change_commission(validator_id: Union[int, str], commission: int) -> str:
-    return "0x" + constants.CHANGE_COMMISSION_SELECTOR + eth_abi.encode(['uint64', 'uint256'], [validator_id, commission]).hex()
+    return "0x" + constants.CHANGE_COMMISSION_SELECTOR + encode(['uint64', 'uint256'], [validator_id, commission]).hex()
 
 def get_epoch() -> str:
     return "0x" + constants.GET_EPOCH_SELECTOR
 
 def get_validator(validator_id: Union[int, str]) -> str:
-    return "0x" + constants.GET_VALIDATOR_SELECTOR + eth_abi.encode(['uint64'], [validator_id]).hex()
+    return "0x" + constants.GET_VALIDATOR_SELECTOR + encode(['uint64'], [validator_id]).hex()
 
 def get_delegator(validator_id: Union[int, str], delegator_address: str) -> str:
-    address_hex = strip_0x(delegator_address)
-    return "0x" + constants.GET_DELEGATOR_SELECTOR + eth_abi.encode(['uint64', 'address'], [validator_id, address_hex]).hex()
+    address_bytes = _address_to_bytes(delegator_address)
+    return "0x" + constants.GET_DELEGATOR_SELECTOR + encode(['uint64', 'address'], [validator_id, address_bytes]).hex()
 
 def get_withdrawal_request(validator_id: Union[int, str], delegator_address: str, withdrawal_id: int) -> str:
-    address_hex = strip_0x(delegator_address)
-    return "0x" + constants.GET_WITHDRAWAL_REQUEST_SELECTOR + eth_abi.encode(['uint64', 'address', 'uint8'], [int(validator_id), address_hex, withdrawal_id]).hex()
+    address_bytes = _address_to_bytes(delegator_address)
+    return "0x" + constants.GET_WITHDRAWAL_REQUEST_SELECTOR + encode(['uint64', 'address', 'uint8'], [int(validator_id), address_bytes, withdrawal_id]).hex()
 
 def get_consensus_valset(index: Union[int, str]) -> str:
-    return "0x" + constants.GET_CONSENSUS_VALSET_SELECTOR + eth_abi.encode(['uint64'], [index]).hex()
+    return "0x" + constants.GET_CONSENSUS_VALSET_SELECTOR + encode(['uint64'], [index]).hex()
 
 def get_snapshot_valset(index: Union[int, str]) -> str:
-    return "0x" + constants.GET_SNAPSHOT_VALSET_SELECTOR + eth_abi.encode(['uint64'], [index]).hex()
+    return "0x" + constants.GET_SNAPSHOT_VALSET_SELECTOR + encode(['uint64'], [index]).hex()
 
 def get_execution_valset(index: Union[int, str]) -> str:
-    return "0x" + constants.GET_EXECUTION_VALSET_SELECTOR + eth_abi.encode(['uint64'], [index]).hex()
+    return "0x" + constants.GET_EXECUTION_VALSET_SELECTOR + encode(['uint64'], [index]).hex()
 
 def get_delegations(delegator_address: str, index: int) -> str:
-    address_hex = delegator_address[2:] if delegator_address.startswith("0x") else delegator_address
-    return "0x" + constants.GET_DELEGATIONS_SELECTOR + eth_abi.encode(['address','uint64'], [address_hex, index]).hex()
+    address_bytes = _address_to_bytes(delegator_address)
+    return "0x" + constants.GET_DELEGATIONS_SELECTOR + encode(['address','uint64'], [address_bytes, index]).hex()
 
 def get_delegators(val_id: int, delegator_address: str) -> str:
-    address_hex = delegator_address[2:] if delegator_address.startswith("0x") else delegator_address
-    return "0x" + constants.GET_DELEGATORS_SELECTOR + eth_abi.encode(['uint64', 'address'], [val_id, address_hex]).hex()
+    address_bytes = _address_to_bytes(delegator_address)
+    return "0x" + constants.GET_DELEGATORS_SELECTOR + encode(['uint64', 'address'], [val_id, address_bytes]).hex()


### PR DESCRIPTION
## Summary
- ensure getter calldata builders convert hex addresses to 20-byte values before ABI encoding
- add validation for address inputs to catch malformed values early
- consolidate ABI encoding usage to the shared encode helper

## Testing
- PYTHONPATH=src python - <<'PY'
from staking_sdk_py.generateCalldata import get_delegator
print(get_delegator(1, '0x' + '12'*20))
PY

------
https://chatgpt.com/codex/tasks/task_e_68e4f3046714832e870b112c0973eee7